### PR TITLE
Fix Module System Error for Komet with JPro

### DIFF
--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -187,6 +187,7 @@
 
 											exports com.google.common.annotations;
 											exports com.google.common.base;
+											exports com.google.common.base.internal;
 											exports com.google.common.cache;
 											exports com.google.common.collect;
 											exports com.google.common.escape;


### PR DESCRIPTION
Problem: Running the Komet application with JPro triggers a module system error due to restricted access to Guava's internal package.

<img width="1632" alt="guava internal" src="https://github.com/user-attachments/assets/df70fdc1-a804-4191-8b57-330d24dfe0ca">

Solution: Added the following line to Guava's module-info.java to export the necessary internal package:
`exports com.google.common.base.internal;`

This change allows JPro to access Guava's internal classes, resolving the module system complaint and ensuring the Komet application runs smoothly.